### PR TITLE
Adding jslint-stylish to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
     "jshint": "^2.9.1",
+    "jshint-stylish": "^2.1.0",
     "karma": "^0.13.21",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.2",


### PR DESCRIPTION
When typing `gulp lint` I got this error:
```
$ gulp lint
[10:16:58] Using gulpfile ~/mozilla/reviews/html-tagged-template/gulpfile.js
[10:16:58] Starting 'lint'...
[10:16:58] 'lint' errored after 13 ms
[10:16:58] Error in plugin 'gulp-jshint'
Message:
    Invalid reporter
```

The commit in this pull request should fix it.
