### PR TITLE
DOM Clobbering test

### DIFF
--- a/test/xss.test.js
+++ b/test/xss.test.js
@@ -78,4 +78,12 @@ describe('XSS Attack Vectors', function() {
     document.body.appendChild(el);
     el.click();
   });
+  it('should prevent against clobbering of /attributes/', function() {
+    var el = html`<form id="f" action="javascript:assert(false)">
+			<input type="radio" name="attributes"//>
+			<input type="submit" />
+		</form>`;
+   document.body.appendChild(el);
+   el.submit();
+  });
 });


### PR DESCRIPTION
The current way to inspect `node.attributes` is prone to DOM clobbering, e.g., the code will look at child elements with `name="attributes"` instead of the actual attributes.

I suppose this needs discussion on how you want to fix these issues. The DOMPurify library handles this by [checking nodes before accessing their properties](https://github.com/cure53/DOMPurify/blob/924a4ac5151c3f6b7fd8a7654c370bf2ae253b28/src/purify.js#L398):
```
    /**
     * _isClobbered
     *
     * @param  element to check for clobbering attacks
     * @return true if clobbered, false if safe
     */
    var _isClobbered = function(elm) {
        if (elm instanceof Text || elm instanceof Comment) {
            return false;
        }
        if (  typeof elm.nodeName !== 'string'
           || typeof elm.textContent !== 'string'
           || typeof elm.removeChild !== 'function'
           || !(elm.attributes instanceof NamedNodeMap)
           || typeof elm.removeAttribute !== 'function'
           || typeof elm.setAttribute !== 'function'
        ) {
            return true;
        }
        return false;
    };
```