### PR TITLE
Contextual auto-escaping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 coverage
 sauce_connect.log
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4.0"
 addons:
   firefox: "42.0"
 before_script:

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ if (typeof window.html === 'undefined') {
 
   // find all attributes after the first whitespace (which would follow the tag
   // name. Only used when the DOM has been clobbered to still parse attributes
-  const ATTRIBUTE_PARSER_REGEX = /\s(\S+)/g;
+  const ATTRIBUTE_PARSER_REGEX = /\s([^">=\s]+)(?:="[^"]+")?/g;
 
   // test if a javascript substitution is wrapped with quotes
   const WRAPPED_WITH_QUOTES_REGEX = /^('|")[\s\S]*\1$/;

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ if (typeof window.html === 'undefined') {
 
   // find all attributes after the first whitespace (which would follow the tag
   // name. Only used when the DOM has been clobbered to still parse attributes
-  const ATTRIBUTE_PARSER_REGEX = /\s(\S+)/g
+  const ATTRIBUTE_PARSER_REGEX = /\s(\S+)/g;
 
   // test if a javascript substitution is wrapped with quotes
   const WRAPPED_WITH_QUOTES_REGEX = /^('|")[\s\S]*\1$/;
@@ -267,7 +267,9 @@ if (typeof window.html === 'undefined') {
             let isRejected = false;
 
             value = value.replace(SUBSTITUTION_REGEX, function(match, index, offset) {
-              if (isRejected) return '';
+              if (isRejected) {
+                return '';
+              }
 
               let substitutionValue = values[parseInt(index, 10)];
 

--- a/index.js
+++ b/index.js
@@ -14,12 +14,63 @@ try {
 catch (e) {
   // missing support;
   console.log('Your browser does not support the needed functionality to use the html tagged template');
+  return;
 }
 
 if (typeof window.html === 'undefined') {
 
   var substitutionIndex = 'substitutionindex:';  // tag names are always all lowercase
   var substitutionRegex = new RegExp(substitutionIndex + '([0-9]+):', 'g');
+
+  // find all attributes after the first whitespace (which would follow the tag
+  // name. Only used when the DOM has been clobbered to still parse attributes
+  var fallbackAttributeParserRegex = /\s(\S+)/g
+
+  // rejection string is used to replace xss attacks that cannot be escaped either
+  // because the escaped string is still executable
+  // (e.g. setTimeout(/* escaped string */)) or because it produces invalid results
+  // (e.g. <h${xss}> where xss='><script>alert(1337)</script')
+  // @see https://developers.google.com/closure/templates/docs/security#in_tags_and_attrs
+  var rejectionString = 'zSubstitutionRejectedz';
+
+  // test if a javascript substitution is wrapped with quotes
+  var wrappedWithQuotesRegex = /^('|")[\s\S]*\1$/;
+
+  // which characters should be encoded in which contexts
+  var encodings = {
+    attribute: {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;'
+    }
+  };
+
+  var encodingRegexs = {
+    attribute: new RegExp('[' + Object.keys(encodings.attribute).join('') + ']', 'g')
+  };
+
+  // which attributes are DOM Level 0 events
+  // taken from https://en.wikipedia.org/wiki/DOM_events#DOM_Level_0
+  var domEvents = ["onclick", "ondblclick", "onmousedown", "onmouseup", "onmouseover", "onmousemove", "onmouseout", "ondragstart", "ondrag", "ondragenter", "ondragleave", "ondragover", "ondrop", "ondragend", "onkeydown", "onkeypress", "onkeyup", "onload", "onunload", "onabort", "onerror", "onresize", "onscroll", "onselect", "onchange", "onsubmit", "onreset", "onfocus", "onblur", "onpointerdown", "onpointerup", "onpointercancel", "onpointermove", "onpointerover", "onpointerout", "onpointerenter", "onpointerleave", "ongotpointercapture", "onlostpointercapture", "oncut", "oncopy", "onpaste", "onbeforecut", "onbeforecopy", "onbeforepaste", "onafterupdate", "onbeforeupdate", "oncellchange", "ondataavailable", "ondatasetchanged", "ondatasetcomplete", "onerrorupdate", "onrowenter", "onrowexit", "onrowsdelete", "onrowinserted", "oncontextmenu", "ondrag", "ondragstart", "ondragenter", "ondragover", "ondragleave", "ondragend", "ondrop", "onselectstart", "help", "onbeforeunload", "onstop", "beforeeditfocus", "onstart", "onfinish", "onbounce", "onbeforeprint", "onafterprint", "onpropertychange", "onfilterchange", "onreadystatechange", "onlosecapture", "DOMMouseScroll", "ondragdrop", "ondragenter", "ondragexit", "ondraggesture", "ondragover", "onclose", "oncommand", "oninput", "DOMMenuItemActive", "DOMMenuItemInactive", "oncontextmenu", "onoverflow", "onoverflowchanged", "onunderflow", "onpopuphidden", "onpopuphiding", "onpopupshowing", "onpopupshown", "onbroadcast", "oncommandupdate"];
+
+  // which attributes take URIs
+  // taken from https://www.w3.org/TR/html4/index/attributes.html
+  var uriAttributes = ["action", "background", "cite", "classid", "codebase", "data", "href", "longdesc", "profile", "src", "usemap"];
+
+  // allow custom attribute names that start or end with url or ui to do uri escaping
+  var customUriAttribute = /\bur[il]|ur[il]s?$/i;
+
+  /**
+   * Escape HTML entities in an attribute.
+   * @param {string} str - String to escape.
+   *
+   * @returns {string}
+   */
+  function encodeAttributeHTMLEntities(str) {
+    return str.replace(encodingRegexs.attribute, function(match) {
+      return encodings.attribute[match];
+    });
+  }
 
   window.html = function(strings, ...values) {
     // break early if called with empty content
@@ -59,6 +110,10 @@ if (typeof window.html === 'undefined') {
         nodeName = nodeName.replace(substitutionRegex, replaceSubstitution);
 
         // createElement() should not need to be escaped to prevent XSS?
+
+        // this will throw an error if the tag name is invalid (e.g. xss tried
+        // to escape out of the tag using '><script>alert(1337)</script><')
+        // instead of replacing the tag name we'll just let the error be thrown
         tag = document.createElement(nodeName);
         node._replacedWith = tag;
 
@@ -72,7 +127,7 @@ if (typeof window.html === 'undefined') {
       // tag to not be executed when added to the DOM. We'll need to create a script
       // tag and append it's contents which will make it execute correctly.
       // @see http://stackoverflow.com/questions/1197575/can-scripts-be-inserted-with-innerhtml
-      if ((tag || node).nodeName === 'SCRIPT') {
+      else if ((tag || node).nodeName === 'SCRIPT') {
         var script = document.createElement('script');
         node._replacedWith = script;
 
@@ -83,7 +138,38 @@ if (typeof window.html === 'undefined') {
 
       // node attributes
       var attributes;
-      if (attributes = node.attributes) {
+      if (node.attributes) {
+
+        // if the attributes property is not of type NamedNodeMap then the DOM
+        // has been clobbered. E.g. <form><input name="attributes"></form>.
+        // We'll manually build up an array of objects that mimic the Attr
+        // object so the loop will still work as expected.
+        if ( !(node.attributes instanceof NamedNodeMap) ) {
+          // first clone the node so we can isolate it from any children
+          var temp = node.cloneNode();
+
+          // parse the node string for all attributes
+          var attributeMatches = temp.outerHTML.match(fallbackAttributeParserRegex);
+
+          // get all attribute names and their value
+          attributes = [];
+          for (var i = 0; i < attributeMatches.length; i++) {
+            var attributeName = attributeMatches[i].trim().split('=')[0];
+            var attributeValue = node.getAttribute(attributeName);
+
+            attributes.push({
+              name: attributeName,
+              value: attributeValue
+            });
+          }
+        }
+        else {
+          // Windows 10 Firefox 44 will shift the attributes NamedNodeMap and push
+          // the attribute to the end when using setAttribute(). We'll have to clone
+          // the NamedNodeMap so the order isn't changed for setAttribute()
+          attributes = Array.from(node.attributes);
+        }
+
         for (var i = 0; i < attributes.length; i++) {
           var attribute = attributes[i];
           var name = attribute.name;
@@ -102,26 +188,48 @@ if (typeof window.html === 'undefined') {
           // value has substitution
           if (value.indexOf(substitutionIndex) !== -1) {
             hasSubstitution = true;
-            value = value.replace(substitutionRegex, replaceSubstitution);
+            value = value.replace(substitutionRegex, function(match, index) {
+              var substitutionValue = values[parseInt(index, 10)];
 
-            // contextual auto escape
-            if (name === 'href') {
-              // URI encode then only allow the : when used after http or https
-              // (will not allow any 'javascript:' or filter evasion techniques)
-              value = encodeURI(value).replace(':', function(match, index, string) {
-                  var protocol = string.substring(index-5, index);
-                  if (protocol.indexOf('http') !== -1) {
-                    return match;
-                  }
+              // contextual auto-escaping:
+              // if attribute is a DOM Level 0 event then we need to ensure it
+              // is quoted
+              if (domEvents.indexOf(name) !== -1 &&
+                  typeof substitutionValue === 'string' &&
+                  !wrappedWithQuotesRegex.test(substitutionValue) ) {
+                substitutionValue = '"' + substitutionValue + '"';
+              }
 
-                  return '\\x' + match.charCodeAt(0).toString(16).toUpperCase();
-              });
+              return substitutionValue;
+            });
+
+            // contextual auto-escaping:
+            if (uriAttributes.indexOf(name) !== -1 || customUriAttribute.test(name)) {
+              value = encodeURI(value);
+
+              // only allow the : when used after http or https otherwise reject
+              // the entire url (will not allow any 'javascript:' or filter
+              // evasion techniques)
+              var index = value.indexOf(':');
+              if (index !== -1) {
+                var protocol = value.substring(index-5, index);
+                if (protocol.indexOf('http') === -1) {
+                  value = '#' + rejectionString;
+                }
+              }
+            }
+
+            // contextual auto-escaping:
+            // HTML encode attribute value if it is not a URL or URI to prevent
+            // DOM Level 0 event handlers from executing xss code
+            else if (typeof value === 'string') {
+              value = encodeAttributeHTMLEntities(value);
             }
           }
 
           // add the attribute to the new tag or replace it on the current node
           // setAttribute() does not need to be escaped to prevent XSS since it does
-          // all of that for use
+          // all of that for us
           // @see https://www.mediawiki.org/wiki/DOM-based_XSS
           if (tag || hasSubstitution) {
             (tag || node).setAttribute(name, value);
@@ -155,11 +263,9 @@ if (typeof window.html === 'undefined') {
       }
     }
 
-    // return an array of childNodes instead of an HTMLCollection, compliant with
-    // the new DOM spec to make collections an Array
-    // @see https://dom.spec.whatwg.org/#element-collections
+    // return the documentFragment for multiple nodes
     if (template.content.childNodes.length > 1) {
-      return Array.from(template.content.childNodes);
+      return template.content;
     }
 
     return template.content.firstChild;

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -18,21 +18,21 @@ module.exports = function (config) {
       platform: 'OS X 10.11',
       browserName: 'chrome',
     },
-    // OSX_Firefox: {
-    //   base: 'SauceLabs',
-    //   platform: 'OS X 10.11',
-    //   browserName: 'firefox'
-    // },
-    // Windows_Chrome: {
-    //   base: 'SauceLabs',
-    //   platform: 'Windows 10',
-    //   browserName: 'chrome',
-    // },
-    // Windows_Firefox: {
-    //   base: 'SauceLabs',
-    //   platform: 'Windows 10',
-    //   browserName: 'firefox'
-    // },
+    OSX_Firefox: {
+      base: 'SauceLabs',
+      platform: 'OS X 10.11',
+      browserName: 'firefox'
+    },
+    Windows_Chrome: {
+      base: 'SauceLabs',
+      platform: 'Windows 10',
+      browserName: 'chrome',
+    },
+    Windows_Edge: {
+      base: 'SauceLabs',
+      platform: 'Windows 10',
+      browserName: 'MicrosoftEdge'
+    }
   }
 
   config.set({

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -1,4 +1,10 @@
 module.exports = function (config) {
+  try {
+    require('dotenv').config();
+  } catch(e) {
+
+  }
+
   if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
     console.log('Make sure the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables are set.')
     process.exit(1)

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -12,21 +12,21 @@ module.exports = function (config) {
       platform: 'OS X 10.11',
       browserName: 'chrome',
     },
-    OSX_Firefox: {
-      base: 'SauceLabs',
-      platform: 'OS X 10.11',
-      browserName: 'firefox'
-    },
-    Windows_Chrome: {
-      base: 'SauceLabs',
-      platform: 'Windows 10',
-      browserName: 'chrome',
-    },
-    Windows_Firefox: {
-      base: 'SauceLabs',
-      platform: 'Windows 10',
-      browserName: 'firefox'
-    },
+    // OSX_Firefox: {
+    //   base: 'SauceLabs',
+    //   platform: 'OS X 10.11',
+    //   browserName: 'firefox'
+    // },
+    // Windows_Chrome: {
+    //   base: 'SauceLabs',
+    //   platform: 'Windows 10',
+    //   browserName: 'chrome',
+    // },
+    // Windows_Firefox: {
+    //   base: 'SauceLabs',
+    //   platform: 'Windows 10',
+    //   browserName: 'firefox'
+    // },
   }
 
   config.set({

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.6",
+    "dotenv": "^2.0.0",
     "gulp": "^3.9.1",
     "gulp-connect": "^2.3.1",
     "gulp-jshint": "^2.0.0",

--- a/page/index.html
+++ b/page/index.html
@@ -15,11 +15,9 @@ document.body.appendChild(html`<input type="number" min="${min}" max="${max}" na
 document.body.appendChild(html`<div class="container"><div class="row"><div class="col"><h${heading}><span>Hi</span></h${heading}></div></div></div>`);
 
 // sibling nodes
-var nodes = html`<tr><td><span>foo</span></td></tr><tr><td><span>bar</span></td></tr>`;
-nodes.forEach(function(node) {
-  document.body.appendChild(node);
-});
+document.body.appendChild(html`<tr><td><span>foo</span></td></tr><tr><td><span>bar</span></td></tr>`);
 </script>
+
 <!-- xss attack -->
 <script src="xss.js"></script>
 

--- a/page/xss.js
+++ b/page/xss.js
@@ -1,6 +1,6 @@
 // @see https://developers.google.com/closure/templates/docs/security
 var xss = "javascript:/*</style></script>/**/ /<script>1/(alert(1337))//</script>";
-html`<a href="${xss}"
+document.body.appendChild(html`<a href="${xss}"
    onclick="${xss}"
    >${xss}</a>
   <script>var x = '${xss}'</script>
@@ -10,6 +10,4 @@ html`<a href="${xss}"
       background: url(/images?q=${xss});
       left: ${xss}
     }
-  </style>`.forEach(function(node) {
-  document.body.appendChild(node);
-});
+  </style>`);

--- a/test/htmlPaser.test.js
+++ b/test/htmlPaser.test.js
@@ -107,11 +107,11 @@ describe('HTML parser', function() {
     var nodes = html`<tr></tr><tr></tr>`;
 
     // correct node
-    expect(nodes).to.be.instanceof(Array);
-    expect(nodes.length).to.equal(2);
+    expect(nodes).to.be.instanceof(DocumentFragment);
+    expect(nodes.childNodes.length).to.equal(2);
 
     // correct first child
-    var tr = nodes[0];
+    var tr = nodes.querySelectorAll('tr')[0];
     expect(tr.nodeName).to.equal('TR');
     expect(tr.attributes.length, 'more than 1 attribute').to.equal(0);
     expect(tr.children.length, 'more than 1 child').to.equal(0);
@@ -119,7 +119,7 @@ describe('HTML parser', function() {
     expect(tr.textContent).to.be.empty;
 
     // correct second child
-    var tr2 = nodes[0];
+    var tr2 = nodes.querySelectorAll('tr')[1];
     expect(tr2.nodeName).to.equal('TR');
     expect(tr2.attributes.length, 'more than 1 attribute').to.equal(0);
     expect(tr2.children.length, 'more than 1 child').to.equal(0);

--- a/test/xss.test.js
+++ b/test/xss.test.js
@@ -79,12 +79,15 @@ describe('XSS Attack Vectors', function() {
   });
 
   it('should prevent against clobbering of /attributes/', function() {
-    var el = html`<form id="f" action="${xss}">
+    var el = html`<form id="f" action="${xss}" onsubmit="return false;">
       <input type="radio" name="attributes"//>
       <input type="submit" />
     </form>`;
    document.body.appendChild(el);
-   el.submit();
+
+   // el.submit() does not trigger a submit event, so we need to click the submit button
+   // @see http://stackoverflow.com/questions/11557994/jquery-submit-vs-javascript-submit
+   el.querySelector('input[type="submit"]').click();
   });
 
   it('should prevent injection out of a tag name by throwing an error', function() {


### PR DESCRIPTION
**Major:**
* change return type for sibling nodes to be a `DocumentFragment` rather than an array. Makes it much easier to work with as inserting the value into the DOM is as simple as `document.body.appendChild(el)`

**Minor:**
* resolve #9 and #14 by doing a regex parse of the attributes manually. Since the string has already gone through the HTML parser, the `outerHTML` is structured as valid DOM so spaces between attributes are required.
* add contextual auto-escaping as per https://developers.google.com/closure/templates/docs/security
  * DOM Level 0 event properties
  * URIs and URLs
  * HTML value encoding
* add tests for contextual auto-escaping
* switch to use `const` and `let`
* add comments and spacing for better visual organization
